### PR TITLE
Set Allowed DropDataTypes and File Extensions

### DIFF
--- a/ios/Classes/SwiftNativeDragNDropPlugin.swift
+++ b/ios/Classes/SwiftNativeDragNDropPlugin.swift
@@ -45,8 +45,8 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
     let viewId: Int64
     let messenger: FlutterBinaryMessenger
     let channel: FlutterMethodChannel
-    var allowedDropDataTypes: [String]?
-    var allowedDropFileExtensions: [String]?
+    var _allowedDropDataTypes: [String]?
+    var _allowedDropFileExtensions: [String]?
     
     init(
         frame: CGRect,
@@ -89,10 +89,10 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
             }    
           }
           if let dropDataTypes = flutterArgs["allowedDropDataTypes"] as? [String] {
-              self.allowedDropDataTypes = dropDataTypes
+              self._allowedDropDataTypes = dropDataTypes
           }
           if let dropFileExtensions = flutterArgs["allowedDropFileExtensions"] as? [String] {
-              self.allowedDropFileExtensions = dropFileExtensions
+              self._allowedDropFileExtensions = dropFileExtensions
           }
         }
         let dropInteraction = UIDropInteraction(delegate: self)
@@ -114,11 +114,11 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
     public func dropInteraction(_ interaction: UIDropInteraction, canHandle session: UIDropSession) -> Bool {
         // If no data types are specified, allow all types
         var allowedTypeIdentifiers: [String] = []
-        if allowedDropDataTypes == nil {
+        if _allowedDropDataTypes == nil {
             allowedTypeIdentifiers.append(contentsOf: [kUTTypeImage as String, kUTTypeMovie as String, kUTTypeAudio as String, kUTTypePlainText as String, kUTTypePDF as String, kUTTypeURL as String, kUTTypeData as String])
         }
         else {
-            for dropType in allowedDropDataTypes! {
+            for dropType in _allowedDropDataTypes! {
                 if dropType == "text" {
                     allowedTypeIdentifiers.append(kUTTypePlainText as String)
                 }
@@ -145,7 +145,7 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
 
         
 
-        if allowedDropFileExtensions == nil {
+        if _allowedDropFileExtensions == nil {
             return session.hasItemsConforming(toTypeIdentifiers: allowedTypeIdentifiers)
         }
 
@@ -171,7 +171,7 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
             droppedFileExtensionList.append(extensionName!.lowercased())
         }
 
-        let hasItemsWithAllowedExtensions: Bool = Set(droppedFileExtensionList).intersection(Set(allowedDropFileExtensions!)).count > 0
+        let hasItemsWithAllowedExtensions: Bool = Set(droppedFileExtensionList).intersection(Set(_allowedDropFileExtensions!)).count > 0
         
         // Converting extensions to UTI to check if the dropped files match does not work because not all filetypes have a UTI
 //        // Convert the file extension to Uniform Type Identifier to

--- a/ios/Classes/SwiftNativeDragNDropPlugin.swift
+++ b/ios/Classes/SwiftNativeDragNDropPlugin.swift
@@ -188,9 +188,9 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
 //        }
 //        let hasItemsWithAllowedExtensions: Bool = Set(allowedExtensionTypeIdentifierList).intersection(UTIList).count > 0
 //        let hasItemsConformingToOtherTypeIdentifiers: Bool = session.hasItemsConforming(toTypeIdentifiers: allowedTypeIdentifiers.filter({$0 != kUTTypeData as String}))
-        let hasItemsConformingToOtherTypeIdentifiers: Bool = session.hasItemsConforming(toTypeIdentifiers: allowedTypeIdentifiers)
+        let hasItemsConformingToTypeIdentifiers: Bool = session.hasItemsConforming(toTypeIdentifiers: allowedTypeIdentifiers)
 
-        return hasItemsWithAllowedExtensions || hasItemsConformingToOtherTypeIdentifiers
+        return hasItemsWithAllowedExtensions || hasItemsConformingToTypeIdentifiers
         
     }
 

--- a/lib/src/drop_view_controller.dart
+++ b/lib/src/drop_view_controller.dart
@@ -62,6 +62,11 @@ class DropViewController {
         var pdf = File(d['pdf'] as String);
         var dropData = DropData(type: DropDataType.pdf, dropFile: pdf);
         dropDataList.add(dropData);
+      } else if (d['file'] != null) {
+        //add pdf
+        var file = File(d['file'] as String);
+        var dropData = DropData(type: DropDataType.file, dropFile: file);
+        dropDataList.add(dropData);
       }
     }
     loadingCallback(false);
@@ -69,7 +74,7 @@ class DropViewController {
   }
 }
 
-enum DropDataType { text, url, image, video, audio, pdf }
+enum DropDataType { text, url, image, video, audio, pdf, file }
 
 class DropData {
   File? dropFile;

--- a/lib/src/native_drop_view.dart
+++ b/lib/src/native_drop_view.dart
@@ -16,17 +16,27 @@ class NativeDropView extends StatefulWidget {
   final DropViewLoadingCallback loadingCallback;
   final DropViewDataReceivedCallback dataReceivedCallback;
 
-  const NativeDropView(
-      {Key? key,
-      required this.child,
-      this.width,
-      this.height,
-      this.backgroundColor,
-      this.borderColor,
-      this.borderWidth,
-      required this.loadingCallback,
-      required this.dataReceivedCallback})
-      : super(key: key);
+  /// Restrict the types of data that can be dropped. All [DropDataType] will be accepted if this is null
+  final List<DropDataType>? allowedDropDataTypes;
+
+  /// Restrict the types of files that can be dropped in addition to files allowed by `allowedDropDataTypes`. All file types included in `allowedDropDataTypes` will be accepted if this is null.
+  ///
+  /// Note that this won't affect files if their data type is included in `allowedDropDataTypes`
+  final List<String>? allowedDropFileExtensions;
+
+  const NativeDropView({
+    Key? key,
+    required this.child,
+    this.width,
+    this.height,
+    this.backgroundColor,
+    this.borderColor,
+    this.borderWidth,
+    this.allowedDropDataTypes,
+    this.allowedDropFileExtensions,
+    required this.loadingCallback,
+    required this.dataReceivedCallback,
+  }) : super(key: key);
 
   @override
   State<NativeDropView> createState() => _NativeDropViewState();
@@ -63,6 +73,12 @@ class _NativeDropViewState extends State<NativeDropView> {
                       ]
                     : [],
                 "borderWidth": widget.borderWidth ?? 0,
+                "allowedDropDataTypes": widget.allowedDropDataTypes
+                    ?.map((dropDataType) => dropDataType.name)
+                    .toList(),
+                "allowedDropFileExtensions": widget.allowedDropFileExtensions
+                    ?.map((fileExt) => fileExt.toLowerCase())
+                    .toList(),
               },
               creationParamsCodec: NativeDropView._decoder,
             ),


### PR DESCRIPTION
Add DropDataType.file to allow dropping any file
Support restricting what types of DropDataType and file extensions can be dropped

```dart
NativeDropView(
  allowedDropDataTypes: const <DropDataType>[
    DropDataType.image,
  ],
  allowedDropFileExtensions: const <String>[
    'epub',
    'apk',
  ],
  ...
```

Dropping is allowed when the dropping session contains an item that conforms to one of the `allowedDropDataTypes` OR when the file extension is included in `allowedDropFileExtensions`

I see that you've made some commits since I started working which has caused some conflicts. Let me know if you need me to resolve them.