### PR TITLE
Fix Dropping Bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.0.3+2
+* Added boolean `NativeDropView.receiveNonAllowedItems` to allow non-allowed items to be dropped if at least one item in the dropping session was allowed
+* Fixed a bug where files such as PDF would be categorized as DropDataType.pdf even if only DropDataType.file was allowed
+* Fixed a bug where documents (such as .numbers) dropped from iCloud would not be accepted
+* Refactor iOS Swift code for readability
+
+Thank you @getBoolean
+
 ## 0.0.3+1
 * Files from iCloud no longer need to be added directly to allowedDropFileExtensions when dataType == DropDataType.file 
 * Updated Readme

--- a/example/lib/src/dropped_image_list_title.dart
+++ b/example/lib/src/dropped_image_list_title.dart
@@ -30,6 +30,7 @@ class DroppedImageListTile extends StatelessWidget {
               backgroundImage: MemoryImage(snapshot.data!),
             ),
             title: Text(dropData.dropFile?.path ?? 'Path unknown'),
+            subtitle: Text(dropData.type.toString()),
           );
         }
 
@@ -39,6 +40,7 @@ class DroppedImageListTile extends StatelessWidget {
             child: CircularProgressIndicator(),
           ),
           title: Text(dropData.dropFile?.path ?? 'Path unknown'),
+          subtitle: Text(dropData.type.toString()),
         );
       },
     );

--- a/example/lib/src/home_view.dart
+++ b/example/lib/src/home_view.dart
@@ -284,6 +284,7 @@ class _ListNativeDropViewState extends State<ListNativeDropView> {
                             if (data.type == DropDataType.text) {
                               return ListTile(
                                 title: Text(data.dropText!),
+                                subtitle: Text(data.type.toString()),
                               );
                             }
                             if (data.type == DropDataType.image) {
@@ -294,6 +295,7 @@ class _ListNativeDropViewState extends State<ListNativeDropView> {
 
                             return ListTile(
                               title: Text(data.dropFile!.path),
+                              subtitle: Text(data.type.toString()),
                             );
                           })
                       : const Center(

--- a/example/lib/src/home_view.dart
+++ b/example/lib/src/home_view.dart
@@ -274,6 +274,7 @@ class _ListNativeDropViewState extends State<ListNativeDropView> {
                   allowedTotal: widget.allowedItemsAtOnce,
                   allowedDropDataTypes: widget.allowedDataTypes,
                   allowedDropFileExtensions: widget.allowedFileExtensions,
+                  receiveNonAllowedItems: false,
                   created: widget.created,
                   child: receivedData.isNotEmpty
                       ? ListView.builder(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -101,7 +101,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.3+1"
+    version: "0.0.3+2"
   path:
     dependency: transitive
     description:

--- a/ios/Classes/SwiftNativeDragNDropPlugin.swift
+++ b/ios/Classes/SwiftNativeDragNDropPlugin.swift
@@ -241,51 +241,6 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
         return session.hasItemsConforming(toTypeIdentifiers: self._allowedTypeIdentifiers) || (hasFile(session) && shouldAllowAllFiles() )
     }
     
-    
-    private func isAllowed(_ item: UIDragItem) -> Bool {
-        return itemConformsToAllowedUTType(item) || (isFile(item) && isFileExtensionAllowed(item))
-    }
-    
-    private func itemConformsToAllowedUTType(_ item: UIDragItem) -> Bool {
-        let itemUTIs: [String] = item.itemProvider.registeredTypeIdentifiers
-        for allowedUTI: String in self._allowedTypeIdentifiers {
-            for itemUTI: String in itemUTIs {
-                if UTTypeConformsTo(itemUTI as CFString, allowedUTI as CFString) {
-                    return true
-                }
-            }
-        }
-        
-        return false
-    }
-    
-    private func isFileExtensionAllowed(_ item: UIDragItem) -> Bool {
-        if shouldAllowAllFiles() {
-            return true
-        }
-        
-        // Files will only be dropped if they have an allowed extension
-        let itemUTIs: [String] = item.itemProvider.registeredTypeIdentifiers
-        var extensions: [String] = []
-        for typeIdentifier: String in itemUTIs {
-            let extensionName = getExtensionCodeFromUTI(typeIdentifier)
-            if extensionName == nil {
-                continue
-            }
-
-            extensions.append(extensionName!.lowercased())
-        }
-        
-        for ext: String in extensions {
-            // `_allowedDropFileExtensions` should never be null because shouldAllowAllFiles() returns true if it is
-            if self._allowedDropFileExtensions!.contains(ext) {
-                return true
-            }
-        }
-        
-        return false
-    }
-    
     public func dropInteraction(_ interaction: UIDropInteraction, canHandle session: UIDropSession) -> Bool {
         
         // If items count is greater than allowed count then can handle returns false
@@ -351,13 +306,8 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
         }
         
         for item in session.items {
-            // Check if item is allowed at all
-            if !isAllowed(item) {
-                continue
-            }
-            
             // Return item with the correct type
-            if item.itemProvider.canLoadObject(ofClass: String.self) && shouldAllowPlainText() {
+            if item.itemProvider.canLoadObject(ofClass: String.self) {
                 group.enter()
 
                 _ = item.itemProvider.loadObject(ofClass: String.self) { reading, err in
@@ -406,7 +356,7 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
 
                 }
             }
-            else if item.itemProvider.canLoadObject(ofClass: NSURL.self) && shouldAllowUrls() {
+            else if item.itemProvider.canLoadObject(ofClass: NSURL.self) {
                 group.enter()
 
                 item.itemProvider.loadObject(ofClass: NSURL.self) { reading, err in

--- a/ios/Classes/SwiftNativeDragNDropPlugin.swift
+++ b/ios/Classes/SwiftNativeDragNDropPlugin.swift
@@ -241,6 +241,51 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
         return session.hasItemsConforming(toTypeIdentifiers: self._allowedTypeIdentifiers) || (hasFile(session) && shouldAllowAllFiles() )
     }
     
+    
+    private func isAllowed(_ item: UIDragItem) -> Bool {
+        return itemConformsToAllowedUTType(item) || (isFile(item) && isFileExtensionAllowed(item))
+    }
+    
+    private func itemConformsToAllowedUTType(_ item: UIDragItem) -> Bool {
+        let itemUTIs: [String] = item.itemProvider.registeredTypeIdentifiers
+        for allowedUTI: String in self._allowedTypeIdentifiers {
+            for itemUTI: String in itemUTIs {
+                if UTTypeConformsTo(itemUTI as CFString, allowedUTI as CFString) {
+                    return true
+                }
+            }
+        }
+        
+        return false
+    }
+    
+    private func isFileExtensionAllowed(_ item: UIDragItem) -> Bool {
+        if shouldAllowAllFiles() {
+            return true
+        }
+        
+        // Files will only be dropped if they have an allowed extension
+        let itemUTIs: [String] = item.itemProvider.registeredTypeIdentifiers
+        var extensions: [String] = []
+        for typeIdentifier: String in itemUTIs {
+            let extensionName = getExtensionCodeFromUTI(typeIdentifier)
+            if extensionName == nil {
+                continue
+            }
+
+            extensions.append(extensionName!.lowercased())
+        }
+        
+        for ext: String in extensions {
+            // `_allowedDropFileExtensions` should never be null because shouldAllowAllFiles() returns true if it is
+            if self._allowedDropFileExtensions!.contains(ext) {
+                return true
+            }
+        }
+        
+        return false
+    }
+    
     public func dropInteraction(_ interaction: UIDropInteraction, canHandle session: UIDropSession) -> Bool {
         
         // If items count is greater than allowed count then can handle returns false
@@ -306,8 +351,13 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
         }
         
         for item in session.items {
+            // Check if item is allowed at all
+            if !isAllowed(item) {
+                continue
+            }
+            
             // Return item with the correct type
-            if item.itemProvider.canLoadObject(ofClass: String.self) {
+            if item.itemProvider.canLoadObject(ofClass: String.self) && shouldAllowPlainText() {
                 group.enter()
 
                 _ = item.itemProvider.loadObject(ofClass: String.self) { reading, err in
@@ -356,7 +406,7 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
 
                 }
             }
-            else if item.itemProvider.canLoadObject(ofClass: NSURL.self) {
+            else if item.itemProvider.canLoadObject(ofClass: NSURL.self) && shouldAllowUrls() {
                 group.enter()
 
                 item.itemProvider.loadObject(ofClass: NSURL.self) { reading, err in

--- a/ios/Classes/SwiftNativeDragNDropPlugin.swift
+++ b/ios/Classes/SwiftNativeDragNDropPlugin.swift
@@ -116,44 +116,43 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
         channel.invokeMethod("loadingData", arguments: "Loading your data")
     }
     
-    private func updateAllowedTotalExtsData(flutterArgs : [String: Any]){
-        if let allowedTotal = flutterArgs["allowedTotal"] as? Int{
-                self._allowedTotal = allowedTotal
-            }
+    private func updateAllowedTotalExtsData(flutterArgs : [String: Any]) {
+        if let allowedTotal = flutterArgs["allowedTotal"] as? Int   {
+            self._allowedTotal = allowedTotal
+        }
         if let dropDataTypes = flutterArgs["allowedDropDataTypes"] as? [String] {
-                self._allowedDropDataTypes = dropDataTypes
-                self._allowedTypeIdentifiers = []
-               for dropType in _allowedDropDataTypes! {
-                    if dropType == "text" {
-                        self._allowedTypeIdentifiers.append(kUTTypePlainText as String)
-                    }
-                    else if dropType == "url" {
-                        self._allowedTypeIdentifiers.append(kUTTypeURL as String)
-                    }
-                    else if dropType == "image" {
-                        self._allowedTypeIdentifiers.append(contentsOf:MediaTypes.IMAGE_IDS)
-                        
-                    }
-                    else if dropType == "video" {
-                        self._allowedTypeIdentifiers.append(contentsOf: MediaTypes.VIDEO_IDS)
-                        
-
-                    }
-                    else if dropType == "audio" {
-                        self._allowedTypeIdentifiers.append(kUTTypeAudio as String)
-                    }
-                    else if dropType == "pdf" {
-                        self._allowedTypeIdentifiers.append(kUTTypePDF as String)
-                    }
-                    else if dropType == "file" {
-                        self._allowedTypeIdentifiers.append(kUTTypeData as String)
-                    }
+            self._allowedDropDataTypes = dropDataTypes
+            self._allowedTypeIdentifiers = []
+            for dropType in _allowedDropDataTypes! {
+                if dropType == "text" {
+                    self._allowedTypeIdentifiers.append(kUTTypePlainText as String)
                 }
-          }
-          if let dropFileExtensions = flutterArgs["allowedDropFileExtensions"] as? [String] {
-              self._allowedDropFileExtensions = dropFileExtensions
+                else if dropType == "url" {
+                    self._allowedTypeIdentifiers.append(kUTTypeURL as String)
+                }
+                else if dropType == "image" {
+                    self._allowedTypeIdentifiers.append(contentsOf:MediaTypes.IMAGE_IDS)
+                    
+                }
+                else if dropType == "video" {
+                    self._allowedTypeIdentifiers.append(contentsOf: MediaTypes.VIDEO_IDS)
+                    
 
-          }
+                }
+                else if dropType == "audio" {
+                    self._allowedTypeIdentifiers.append(kUTTypeAudio as String)
+                }
+                else if dropType == "pdf" {
+                    self._allowedTypeIdentifiers.append(kUTTypePDF as String)
+                }
+                else if dropType == "file" {
+                    self._allowedTypeIdentifiers.append(kUTTypeData as String)
+                }
+            }
+        }
+        if let dropFileExtensions = flutterArgs["allowedDropFileExtensions"] as? [String] {
+          self._allowedDropFileExtensions = dropFileExtensions
+        }
     }
     
     

--- a/ios/Classes/SwiftNativeDragNDropPlugin.swift
+++ b/ios/Classes/SwiftNativeDragNDropPlugin.swift
@@ -50,8 +50,8 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
     var _allowedDropDataTypes: [String]?
     var _allowedDropFileExtensions: [String]?
     var _allowedTypeIdentifiers : [String] = []
-
     private var _allowedTotal : Int = 0
+    
     init(
         frame: CGRect,
         viewIdentifier viewId: Int64,
@@ -156,12 +156,10 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
           }
     }
     
+    
+    
     private func isDirectory(_ item: UIDragItem) -> Bool {
         return item.itemProvider.hasItemConformingToTypeIdentifier(kUTTypeDirectory as String)
-    }
-    
-    private func isNotDirectory(_ item: UIDragItem) -> Bool {
-        return !isDirectory(item)
     }
     
     private func isFileOrDirectory(_ item: UIDragItem) -> Bool {
@@ -169,7 +167,7 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
     }
     
     private func isFile(_ item: UIDragItem) -> Bool {
-        return isNotDirectory(item) && isFileOrDirectory(item)
+        return !isDirectory(item) && isFileOrDirectory(item)
     }
     
     private func getExtensionCodeFromUTI(_ typeIdentifier: String) -> String? {
@@ -233,10 +231,57 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
         return false
     }
     
-    private func hasItemsConformingToTypeIdentifiers(_ session: UIDropSession) -> Bool {
-        let allowFiles = self._allowedTypeIdentifiers.contains(kUTTypeData as String)
+    private func shouldAllowAllFiles() -> Bool {
+        return self._allowedTypeIdentifiers.contains(kUTTypeData as String)
+    }
+    
+    private func hasItemsConformingToAllowedTypeIdentifiers(_ session: UIDropSession) -> Bool {
+        return session.hasItemsConforming(toTypeIdentifiers: self._allowedTypeIdentifiers) || (hasFile(session) && shouldAllowAllFiles() )
+    }
+    
+    
+    private func isAllowed(_ item: UIDragItem) -> Bool {
+        return itemConformsToAllowedUTType(item) || (isFile(item) && isFileExtensionAllowed(item))
+    }
+    
+    private func itemConformsToAllowedUTType(_ item: UIDragItem) -> Bool {
+        let itemUTIs: [String] = item.itemProvider.registeredTypeIdentifiers
+        for allowedUTI: String in self._allowedTypeIdentifiers {
+            for itemUTI: String in itemUTIs {
+                if UTTypeConformsTo(itemUTI as CFString, allowedUTI as CFString) {
+                    return true
+                }
+            }
+        }
         
-        return session.hasItemsConforming(toTypeIdentifiers: self._allowedTypeIdentifiers) || (self.hasFile(session) && allowFiles)
+        return false
+    }
+    
+    private func isFileExtensionAllowed(_ item: UIDragItem) -> Bool {
+        if shouldAllowAllFiles() {
+            return true
+        }
+        
+        // Files will only be dropped if they have an allowed extension
+        let itemUTIs: [String] = item.itemProvider.registeredTypeIdentifiers
+        var extensions: [String] = []
+        for typeIdentifier: String in itemUTIs {
+            let extensionName = getExtensionCodeFromUTI(typeIdentifier)
+            if extensionName == nil {
+                continue
+            }
+
+            extensions.append(extensionName!.lowercased())
+        }
+        
+        for ext: String in extensions {
+            // `_allowedDropFileExtensions` should never be null because shouldAllowAllFiles() returns true if it is
+            if self._allowedDropFileExtensions!.contains(ext) {
+                return true
+            }
+        }
+        
+        return false
     }
     
     public func dropInteraction(_ interaction: UIDropInteraction, canHandle session: UIDropSession) -> Bool {
@@ -251,7 +296,7 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
             return session.hasItemsConforming(toTypeIdentifiers: self._allowedTypeIdentifiers)
         }
         
-        return self.hasAllowedExtensionCode(session) || self.hasItemsConformingToTypeIdentifiers(session)
+        return hasAllowedExtensionCode(session) || hasItemsConformingToAllowedTypeIdentifiers(session)
     }
 
     public func dropInteraction(_ interaction: UIDropInteraction, sessionDidUpdate session: UIDropSession) -> UIDropProposal {
@@ -267,6 +312,10 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
         }
         
         for item in session.items {
+            if !isAllowed(item) {
+                continue
+            }
+            
             if item.itemProvider.canLoadObject(ofClass: String.self) && self._allowedTypeIdentifiers.contains(kUTTypePlainText as String) {
                 group.enter()
 
@@ -415,7 +464,7 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
 
                 }
             }
-            else if item.itemProvider.hasItemConformingToTypeIdentifier(kUTTypeItem as String) && isNotDirectory(item) {
+            else if isFile(item) {
                 group.enter()
 
                 item.itemProvider.loadFileRepresentation(forTypeIdentifier: kUTTypeItem as String) { url, err in

--- a/ios/Classes/SwiftNativeDragNDropPlugin.swift
+++ b/ios/Classes/SwiftNativeDragNDropPlugin.swift
@@ -166,8 +166,16 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
         return item.itemProvider.hasItemConformingToTypeIdentifier(kUTTypeItem as String)
     }
     
+    private func isDocument(_ item: UIDragItem) -> Bool {
+        return item.itemProvider.hasItemConformingToTypeIdentifier(kUTTypeContent as String)
+    }
+    
+    private func isCompositeDocument(_ item: UIDragItem) -> Bool {
+        return item.itemProvider.hasItemConformingToTypeIdentifier(kUTTypeContent as String)
+    }
+    
     private func isFile(_ item: UIDragItem) -> Bool {
-        return !isDirectory(item) && isFileOrDirectory(item)
+        return (!isDirectory(item) && isFileOrDirectory(item)) || isDocument(item) || isCompositeDocument(item)
     }
     
     private func getExtensionCodeFromUTI(_ typeIdentifier: String) -> String? {

--- a/ios/Classes/SwiftNativeDragNDropPlugin.swift
+++ b/ios/Classes/SwiftNativeDragNDropPlugin.swift
@@ -51,6 +51,7 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
     var _allowedDropFileExtensions: [String]?
     var _allowedTypeIdentifiers : [String] = []
     private var _allowedTotal : Int = 0
+    private var _receiveNonAllowedItems: Bool = true;
     
     init(
         frame: CGRect,
@@ -149,6 +150,9 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
         }
         if let dropFileExtensions = flutterArgs["allowedDropFileExtensions"] as? [String] {
           self._allowedDropFileExtensions = dropFileExtensions
+        }
+        if let receiveNonAllowedItems = flutterArgs["receiveNonAllowedItems"] as? Bool {
+          self._receiveNonAllowedItems = receiveNonAllowedItems
         }
     }
     
@@ -352,7 +356,7 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
         
         for item in session.items {
             // Check if item is allowed at all
-            if !isAllowed(item) {
+            if !self._receiveNonAllowedItems && !isAllowed(item) {
                 continue
             }
             

--- a/ios/Classes/SwiftNativeDragNDropPlugin.swift
+++ b/ios/Classes/SwiftNativeDragNDropPlugin.swift
@@ -163,15 +163,13 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
     }
     
     private func isDocument(_ item: UIDragItem) -> Bool {
-        return item.itemProvider.hasItemConformingToTypeIdentifier(kUTTypeContent as String)
-    }
-    
-    private func isCompositeDocument(_ item: UIDragItem) -> Bool {
+        // Can be document, pasteboard data, or  document packages
+        // https://web.archive.org/web/20190621082935/https://developer.apple.com/documentation/mobilecoreservices/uttype/uti_abstract_types
         return item.itemProvider.hasItemConformingToTypeIdentifier(kUTTypeContent as String)
     }
     
     private func isFile(_ item: UIDragItem) -> Bool {
-        return (!isDirectory(item) && isFileOrDirectory(item)) || isDocument(item) || isCompositeDocument(item)
+        return (!isDirectory(item) && isFileOrDirectory(item)) || isDocument(item)
     }
     
     private func getExtensionCodeFromUTI(_ typeIdentifier: String) -> String? {

--- a/ios/Classes/SwiftNativeDragNDropPlugin.swift
+++ b/ios/Classes/SwiftNativeDragNDropPlugin.swift
@@ -50,8 +50,8 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
     var _allowedDropDataTypes: [String]?
     var _allowedDropFileExtensions: [String]?
     var _allowedTypeIdentifiers : [String] = []
+
     private var _allowedTotal : Int = 0
-    
     init(
         frame: CGRect,
         viewIdentifier viewId: Int64,
@@ -76,7 +76,7 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
                 }
               let color = UIColor(red: colorValues[0]/255, green: colorValues[1]/255, blue: colorValues[2]/255, alpha: colorValues[3]/255)
               _view.backgroundColor = color
-            }            
+            }
           }
           if let borderColor = flutterArgs["borderColor"] as? [Int], let borderWidth = flutterArgs["borderWidth"] as? Int{
               if borderColor.count > 0{
@@ -86,15 +86,16 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
               let color = UIColor(red: colorValues[0]/255, green: colorValues[1]/255, blue: colorValues[2]/255, alpha: colorValues[3]/255)
               _view.layer.borderColor = color.cgColor
               _view.layer.borderWidth = CGFloat(borderWidth)
-            }    
+            }
           }
           
         }
 
-        channel.setMethodCallHandler({ [weak self] (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in 
+        channel.setMethodCallHandler({ [weak self] (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
             if call.method == "updateParams"{
                 if let flutterArgs = call.arguments as? [String: Any]{
                     self?.updateAllowedTotalExtsData(flutterArgs: flutterArgs)
+
                 }
             }
         })
@@ -103,44 +104,6 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
 
     }
     
-    private func updateAllowedTotalExtsData(flutterArgs : [String: Any]){
-        if let allowedTotal = flutterArgs["allowedTotal"] as? Int{
-            self._allowedTotal = allowedTotal
-        }
-        if let dropDataTypes = flutterArgs["allowedDropDataTypes"] as? [String] {
-            self._allowedDropDataTypes = dropDataTypes
-            self._allowedTypeIdentifiers = []
-            for dropType in _allowedDropDataTypes! {
-                if dropType == "text" {
-                    self._allowedTypeIdentifiers.append(kUTTypePlainText as String)
-                }
-                else if dropType == "url" {
-                    self._allowedTypeIdentifiers.append(kUTTypeURL as String)
-                }
-                else if dropType == "image" {
-                    self._allowedTypeIdentifiers.append(contentsOf:MediaTypes.IMAGE_IDS)
-                    
-                }
-                else if dropType == "video" {
-                    self._allowedTypeIdentifiers.append(contentsOf: MediaTypes.VIDEO_IDS)
-                    
-
-                }
-                else if dropType == "audio" {
-                    self._allowedTypeIdentifiers.append(kUTTypeAudio as String)
-                }
-                else if dropType == "pdf" {
-                    self._allowedTypeIdentifiers.append(kUTTypePDF as String)
-                }
-                else if dropType == "file" {
-                    self._allowedTypeIdentifiers.append(kUTTypeData as String)
-                }
-            }
-        }
-        if let dropFileExtensions = flutterArgs["allowedDropFileExtensions"] as? [String] {
-            self._allowedDropFileExtensions = dropFileExtensions
-        }
-    }
     public func view() -> UIView {
         return _view
     }
@@ -148,28 +111,75 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
     public func sendDropData(_ data: Any){
         channel.invokeMethod("receivedDropData", arguments: data)
     }
+    
     public func sendLoadingNotification(){
         channel.invokeMethod("loadingData", arguments: "Loading your data")
     }
+    
+    private func updateAllowedTotalExtsData(flutterArgs : [String: Any]){
+        if let allowedTotal = flutterArgs["allowedTotal"] as? Int{
+                self._allowedTotal = allowedTotal
+            }
+        if let dropDataTypes = flutterArgs["allowedDropDataTypes"] as? [String] {
+                self._allowedDropDataTypes = dropDataTypes
+                self._allowedTypeIdentifiers = []
+               for dropType in _allowedDropDataTypes! {
+                    if dropType == "text" {
+                        self._allowedTypeIdentifiers.append(kUTTypePlainText as String)
+                    }
+                    else if dropType == "url" {
+                        self._allowedTypeIdentifiers.append(kUTTypeURL as String)
+                    }
+                    else if dropType == "image" {
+                        self._allowedTypeIdentifiers.append(contentsOf:MediaTypes.IMAGE_IDS)
+                        
+                    }
+                    else if dropType == "video" {
+                        self._allowedTypeIdentifiers.append(contentsOf: MediaTypes.VIDEO_IDS)
+                        
+
+                    }
+                    else if dropType == "audio" {
+                        self._allowedTypeIdentifiers.append(kUTTypeAudio as String)
+                    }
+                    else if dropType == "pdf" {
+                        self._allowedTypeIdentifiers.append(kUTTypePDF as String)
+                    }
+                    else if dropType == "file" {
+                        self._allowedTypeIdentifiers.append(kUTTypeData as String)
+                    }
+                }
+          }
+          if let dropFileExtensions = flutterArgs["allowedDropFileExtensions"] as? [String] {
+              self._allowedDropFileExtensions = dropFileExtensions
+
+          }
+    }
+    
     private func isDirectory(_ item: UIDragItem) -> Bool {
         return item.itemProvider.hasItemConformingToTypeIdentifier(kUTTypeDirectory as String)
     }
+    
+    private func isNotDirectory(_ item: UIDragItem) -> Bool {
+        return !isDirectory(item)
+    }
+    
     private func isFileOrDirectory(_ item: UIDragItem) -> Bool {
         return item.itemProvider.hasItemConformingToTypeIdentifier(kUTTypeItem as String)
     }
-    public func dropInteraction(_ interaction: UIDropInteraction, canHandle session: UIDropSession) -> Bool {
-        
-        // If items count is greater than allowed count then can handle returns false
-        if self._allowedTotal > 0 && session.items.count > self._allowedTotal{
-            return false
-        }      
-        
-        // If no data types are specified, allow all types
-        if self._allowedDropFileExtensions == nil {
-            return session.hasItemsConforming(toTypeIdentifiers: self._allowedTypeIdentifiers)
-        }
-
-        // Use the Uniform Type Identifiers to get the file extensions since 
+    
+    private func isFile(_ item: UIDragItem) -> Bool {
+        return isNotDirectory(item) && isFileOrDirectory(item)
+    }
+    
+    private func getExtensionCodeFromUTI(_ typeIdentifier: String) -> String? {
+        let cfExtensionName = UTTypeCopyPreferredTagWithClass(typeIdentifier as CFString, kUTTagClassFilenameExtension)
+        let extensionName = cfExtensionName?.takeRetainedValue() as String?
+        return extensionName
+    }
+    
+    private func getSessionExtensionCodes(_ session: UIDropSession) -> [String] {
+        // Use the Uniform Type Identifiers to get the file extensions since
         // `session.items.first?.itemProvider.suggestedName` does not include the file extension
         var UTIList: [String] = []
         for item: UIDragItem in session.items {
@@ -181,29 +191,15 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
         // Convert Uniform Type Identifier to Extension, code found here: https://stackoverflow.com/questions/49118095/ios-11-extracting-filename-when-doing-drag-and-drop-pdf-from-dropbox
         var droppedFileExtensionList: [String] = []
         for typeIdentifier: String in UTIList {
-            let cfExtensionName = UTTypeCopyPreferredTagWithClass(typeIdentifier as CFString, kUTTagClassFilenameExtension)
-            let extensionName = cfExtensionName?.takeRetainedValue() as String?
-
-            guard extensionName != nil else {
+            let extensionName = getExtensionCodeFromUTI(typeIdentifier)
+            if extensionName == nil {
                 continue
             }
 
             droppedFileExtensionList.append(extensionName!.lowercased())
         }
-
-        let hasItemsWithAllowedExtensions: Bool = Set(droppedFileExtensionList).intersection(Set(self._allowedDropFileExtensions!)).count > 0
         
-        var hasFile: Bool = false
-        for item: UIDragItem in session.items {
-            if !isDirectory(item) && isFileOrDirectory(item) {
-                hasFile = true
-                break
-            }
-        }
-        
-        let allowFiles = self._allowedTypeIdentifiers.contains(kUTTypeData as String)
-        
-        // Converting extensions to UTI to check if the dropped files match does not work because not all filetypes have a UTI
+//        // Converting extensions to UTI to check if the dropped files matches does not work because not all filetypes have a UTI
 //        // Convert the file extension to Uniform Type Identifier to
 //        var allowedExtensionTypeIdentifierList: [String] = []
 //        for fileExtension: String in allowedDropFileExtensions! {
@@ -218,9 +214,44 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
 //        }
 //        let hasItemsWithAllowedExtensions: Bool = Set(allowedExtensionTypeIdentifierList).intersection(UTIList).count > 0
 //        let hasItemsConformingToOtherTypeIdentifiers: Bool = session.hasItemsConforming(toTypeIdentifiers: allowedTypeIdentifiers.filter({$0 != kUTTypeData as String}))
-        let hasItemsConformingToTypeIdentifiers: Bool = session.hasItemsConforming(toTypeIdentifiers: self._allowedTypeIdentifiers)
-
-        return hasItemsWithAllowedExtensions || hasItemsConformingToTypeIdentifiers || (hasFile && allowFiles)
+        
+        return droppedFileExtensionList
+    }
+    
+    private func hasAllowedExtensionCode(_ session: UIDropSession) -> Bool {
+        let extensionCodes = getSessionExtensionCodes(session)
+        return Set(extensionCodes).intersection(Set(self._allowedDropFileExtensions!)).count > 0
+    }
+    
+    private func hasFile(_ session: UIDropSession) -> Bool {
+        for item: UIDragItem in session.items {
+            if isFile(item) {
+                return true
+            }
+        }
+        
+        return false
+    }
+    
+    private func hasItemsConformingToTypeIdentifiers(_ session: UIDropSession) -> Bool {
+        let allowFiles = self._allowedTypeIdentifiers.contains(kUTTypeData as String)
+        
+        return session.hasItemsConforming(toTypeIdentifiers: self._allowedTypeIdentifiers) || (self.hasFile(session) && allowFiles)
+    }
+    
+    public func dropInteraction(_ interaction: UIDropInteraction, canHandle session: UIDropSession) -> Bool {
+        
+        // If items count is greater than allowed count then can handle returns false
+        if self._allowedTotal != 0 && session.items.count > self._allowedTotal {
+            return false
+        }
+        
+        // If no data types are specified, allow all types
+        if self._allowedDropFileExtensions == nil {
+            return session.hasItemsConforming(toTypeIdentifiers: self._allowedTypeIdentifiers)
+        }
+        
+        return self.hasAllowedExtensionCode(session) || self.hasItemsConformingToTypeIdentifiers(session)
     }
 
     public func dropInteraction(_ interaction: UIDropInteraction, sessionDidUpdate session: UIDropSession) -> UIDropProposal {
@@ -234,7 +265,8 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
         if (session.items.count > 0){
             sendLoadingNotification()
         }
-        for item in session.items{
+        
+        for item in session.items {
             if item.itemProvider.canLoadObject(ofClass: String.self) && self._allowedTypeIdentifiers.contains(kUTTypePlainText as String) {
                 group.enter()
 
@@ -246,6 +278,7 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
                             
                             if let imageData = Data(base64Encoded: reading!), let savedURL = self.saveImage(imageData: imageData){
                                 data.append(["image": savedURL])
+
                             }
                         }
                         else {
@@ -382,7 +415,7 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
 
                 }
             }
-            else if item.itemProvider.hasItemConformingToTypeIdentifier(kUTTypeItem as String) && !isDirectory(item){
+            else if item.itemProvider.hasItemConformingToTypeIdentifier(kUTTypeItem as String) && isNotDirectory(item) {
                 group.enter()
 
                 item.itemProvider.loadFileRepresentation(forTypeIdentifier: kUTTypeItem as String) { url, err in
@@ -400,7 +433,7 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
         }
         group.notify(queue: .main) {
             self.sendDropData(data)
-
+            
         }
     }
 
@@ -433,6 +466,7 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
        
         return nil
     }
+    
     func saveImage(imageData : Data) -> String? {
         let fileManager = FileManager()
         let tempFile = NSTemporaryDirectory().appending(UUID().uuidString.appending(".jpeg"))
@@ -445,8 +479,10 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
         if fileManager.createFile(atPath: tempFile, contents: imageData, attributes: nil){
             return tempFile
         }
+        
         return nil
     }
+    
     func saveFileURL(userURL: URL) -> String? {
         let fileManager = FileManager()
 

--- a/ios/Classes/SwiftNativeDragNDropPlugin.swift
+++ b/ios/Classes/SwiftNativeDragNDropPlugin.swift
@@ -132,12 +132,9 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
                 }
                 else if dropType == "image" {
                     self._allowedTypeIdentifiers.append(contentsOf:MediaTypes.IMAGE_IDS)
-                    
                 }
                 else if dropType == "video" {
                     self._allowedTypeIdentifiers.append(contentsOf: MediaTypes.VIDEO_IDS)
-                    
-
                 }
                 else if dropType == "audio" {
                     self._allowedTypeIdentifiers.append(kUTTypeAudio as String)

--- a/ios/Classes/SwiftNativeDragNDropPlugin.swift
+++ b/ios/Classes/SwiftNativeDragNDropPlugin.swift
@@ -473,21 +473,6 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
 
                 }
             }
-            else if item.itemProvider.hasItemConformingToTypeIdentifier(kUTTypePlainText as String) && shouldAllowPlainText() {
-                group.enter()
-
-                item.itemProvider.loadFileRepresentation(forTypeIdentifier: kUTTypePlainText as String) { url, err in
-
-                    if (err == nil && url != nil){
-                        if let fileURL = self.saveFileURL(userURL: url!){
-                            data.append(["plaintext": fileURL])
-
-                        }
-                    }
-                    group.leave()
-
-                }
-            }
             // No need to check if the file extension is allowed here because it was already checked in isAllowed()
             else if isFile(item) {
                 group.enter()

--- a/ios/Classes/SwiftNativeDragNDropPlugin.swift
+++ b/ios/Classes/SwiftNativeDragNDropPlugin.swift
@@ -301,7 +301,7 @@ public class DropPlatformView: NSObject, FlutterPlatformView, UIDropInteractionD
         
         // If no data types are specified, allow all types
         if self._allowedDropFileExtensions == nil {
-            return session.hasItemsConforming(toTypeIdentifiers: self._allowedTypeIdentifiers)
+            return session.hasItemsConforming(toTypeIdentifiers: self._allowedTypeIdentifiers) || (hasFile(session) && shouldAllowAllFiles() )
         }
         
         return hasAllowedExtensionCode(session) || hasItemsConformingToAllowedTypeIdentifiers(session)

--- a/lib/src/drop_view_controller.dart
+++ b/lib/src/drop_view_controller.dart
@@ -88,10 +88,12 @@ class DropViewController {
   /// Set allowedTotal = 0 if you don't want to have a limit
   ///
   /// Must set allowedDropDataTypes or allowedDropFileExtensions
-  refreshDropViewParams(
-      {int? allowedTotal,
-      List<DropDataType>? allowedDropDataTypes,
-      List<String>? allowedDropFileExtensions}) async {
+  refreshDropViewParams({
+    int? allowedTotal,
+    List<DropDataType>? allowedDropDataTypes,
+    List<String>? allowedDropFileExtensions,
+    bool? receiveNonAllowedItems,
+  }) async {
     assert(allowedDropDataTypes != null ||
         allowedDropFileExtensions != null ||
         (allowedTotal != null && allowedTotal >= 0));
@@ -106,6 +108,9 @@ class DropViewController {
     }
     if (allowedDropFileExtensions != null) {
       params['allowedDropFileExtensions'] = allowedDropFileExtensions;
+    }
+    if (receiveNonAllowedItems != null) {
+      params['receiveNonAllowedItems'] = receiveNonAllowedItems;
     }
     if (params.isNotEmpty) {
       print("updated");

--- a/lib/src/native_drop_view.dart
+++ b/lib/src/native_drop_view.dart
@@ -41,6 +41,13 @@ class NativeDropView extends StatefulWidget {
   /// Note that this won't affect files if their data type is included in `allowedDropDataTypes`
   final List<String>? allowedDropFileExtensions;
 
+  /// Receive all dropped items if at least one item is allowed. Defaults to true
+  /// 
+  /// Disable this to only receive items that have been allowed in `allowedDropDataTypes` and `allowedDropFileExtensions`
+  /// 
+  /// It is recommended to keep this enabled and give feedback to the user when they have dropped an item that is not allowed
+  final bool receiveNonAllowedItems;
+
   /// A widget that adds drag and drop functionality
   ///
   /// Must set allowedDropDataTypes or allowedDropFileExtensions
@@ -50,6 +57,7 @@ class NativeDropView extends StatefulWidget {
       this.allowedTotal = 0,
       this.allowedDropDataTypes,
       this.allowedDropFileExtensions,
+      this.receiveNonAllowedItems = true,
       required this.loading,
       required this.dataReceived,
       this.backgroundColor,
@@ -105,6 +113,7 @@ class _NativeDropViewState extends State<NativeDropView> {
                 "allowedDropFileExtensions": widget.allowedDropFileExtensions
                     ?.map((fileExt) => fileExt.toLowerCase())
                     .toList(),
+                "receiveNonAllowedItems": widget.receiveNonAllowedItems,
               },
               creationParamsCodec: NativeDropView._decoder,
             ),

--- a/lib/src/native_drop_view.dart
+++ b/lib/src/native_drop_view.dart
@@ -45,7 +45,7 @@ class NativeDropView extends StatefulWidget {
   /// 
   /// Disable this to only receive items that have been allowed in `allowedDropDataTypes` and `allowedDropFileExtensions`
   /// 
-  /// It is recommended to keep this enabled and give feedback to the user when they have dropped an item that is not allowed
+  /// It is recommended to keep this enabled, and instead give feedback to the user when they have dropped an item that is not allowed.
   final bool receiveNonAllowedItems;
 
   /// A widget that adds drag and drop functionality

--- a/lib/src/native_drop_view.dart
+++ b/lib/src/native_drop_view.dart
@@ -34,6 +34,8 @@ class NativeDropView extends StatefulWidget {
   final int allowedTotal;
 
   /// Restrict the types of data that can be dropped.
+  /// 
+  /// When [DropDataType.file] is allowed, it will also allow [DropDataType.image], [DropDataType.audio], [DropDataType.video], and [DropDataType.pdf]. Their type will be set as [DropDataType.file] unless their type is also included here.
   final List<DropDataType>? allowedDropDataTypes;
 
   /// Restrict the types of files that can be dropped in addition to files allowed by `allowedDropDataTypes`. All file types included in `allowedDropDataTypes` will be accepted if this is null.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: native_drag_n_drop
 description: A package that allows you to add native drag and drop support into your flutter app.
-version: 0.0.3+1
+version: 0.0.3+2
 homepage: https://github.com/alexrabin/FlutterNativeDragAndDrop
 
 environment:


### PR DESCRIPTION
Closes #4

Added a boolean flag to allow non-allowed items to be dropped if at least one item in the dropping session was allowed
Fixed a potential bug where files such as PDF would be categorized as DropDataType.pdf even if only DropDataType.file was allowed
Fixed a bug where documents (.numbers) dropped from iCloud would not be accepted
Refactor code to be more readable